### PR TITLE
Add support for Spark 2.0

### DIFF
--- a/pmml-spark-example/pom.xml
+++ b/pmml-spark-example/pom.xml
@@ -19,7 +19,7 @@
 
 		<dependency>
 			<groupId>com.databricks</groupId>
-			<artifactId>spark-csv_2.10</artifactId>
+			<artifactId>spark-csv_2.11</artifactId>
 			<version>1.3.0</version>
 			<exclusions>
 				<exclusion>
@@ -31,15 +31,15 @@
 
 		<dependency>
 			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-core_2.10</artifactId>
+			<artifactId>spark-core_2.11</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-mllib_2.10</artifactId>
+			<artifactId>spark-mllib_2.11</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-sql_2.10</artifactId>
+			<artifactId>spark-sql_2.11</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/pmml-spark-example/src/main/java/org/jpmml/spark/EvaluationExample.java
+++ b/pmml-spark-example/src/main/java/org/jpmml/spark/EvaluationExample.java
@@ -23,10 +23,11 @@ import java.io.File;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.ml.Transformer;
-import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.DataFrameReader;
 import org.apache.spark.sql.DataFrameWriter;
 import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.Row;
 import org.jpmml.evaluator.Evaluator;
 
 public class EvaluationExample {
@@ -59,7 +60,7 @@ public class EvaluationExample {
 				.option("header", "true")
 				.option("inferSchema", "true");
 
-			DataFrame dataFrame = reader.load(args[1]);
+			Dataset<Row> dataFrame = reader.load(args[1]);
 
 			dataFrame = transformer.transform(dataFrame);
 

--- a/pmml-spark/pom.xml
+++ b/pmml-spark/pom.xml
@@ -20,19 +20,19 @@
 
 		<dependency>
 			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-catalyst_2.10</artifactId>
+			<artifactId>spark-catalyst_2.11</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-core_2.10</artifactId>
+			<artifactId>spark-core_2.11</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-mllib_2.10</artifactId>
+			<artifactId>spark-mllib_2.11</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-sql_2.10</artifactId>
+			<artifactId>spark-sql_2.11</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/pmml-spark/src/main/java/org/jpmml/spark/ColumnExploder.java
+++ b/pmml-spark/src/main/java/org/jpmml/spark/ColumnExploder.java
@@ -21,7 +21,8 @@ package org.jpmml.spark;
 import org.apache.spark.ml.Transformer;
 import org.apache.spark.ml.param.ParamMap;
 import org.apache.spark.sql.Column;
-import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
@@ -59,14 +60,14 @@ public class ColumnExploder extends Transformer {
 	}
 
 	@Override
-	public DataFrame transform(DataFrame dataFrame){
+	public Dataset<Row> transform(Dataset<?> dataFrame){
 		StructType schema = dataFrame.schema();
 
 		StructType structSchema = getStructSchema(schema);
 
 		Column structColumn = dataFrame.apply(getStructCol());
 
-		DataFrame result = dataFrame;
+		Dataset<?> result = dataFrame;
 
 		StructField[] fields = structSchema.fields();
 		for(StructField field : fields){
@@ -77,7 +78,7 @@ public class ColumnExploder extends Transformer {
 			result = result.withColumn(name, fieldColumn);
 		}
 
-		return result;
+		return result.toDF();
 	}
 
 	private StructType getStructSchema(StructType schema){

--- a/pmml-spark/src/main/java/org/jpmml/spark/PMMLTransformer.java
+++ b/pmml-spark/src/main/java/org/jpmml/spark/PMMLTransformer.java
@@ -29,7 +29,7 @@ import com.google.common.collect.Lists;
 import org.apache.spark.ml.Transformer;
 import org.apache.spark.ml.param.ParamMap;
 import org.apache.spark.sql.Column;
-import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.catalyst.expressions.CreateStruct;
@@ -88,7 +88,7 @@ public class PMMLTransformer extends Transformer {
 	}
 
 	@Override
-	public DataFrame transform(final DataFrame dataFrame){
+	public Dataset<Row> transform(final Dataset<?> dataFrame){
 		final
 		Evaluator evaluator = getEvaluator();
 
@@ -148,7 +148,7 @@ public class PMMLTransformer extends Transformer {
 
 		Column outputColumn = new Column(evaluateExpression);
 
-		return dataFrame.withColumn(getOutputCol(), outputColumn);
+		return dataFrame.withColumn(getOutputCol(), outputColumn).toDF();
 	}
 
 	public String[] getInputCols(){

--- a/pom.xml
+++ b/pom.xml
@@ -52,20 +52,20 @@
 
 			<dependency>
 				<groupId>org.apache.spark</groupId>
-				<artifactId>spark-catalyst_2.10</artifactId>
-				<version>[1.5.0, 1.6.2]</version>
+				<artifactId>spark-catalyst_2.11</artifactId>
+				<version>2.0.0</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.spark</groupId>
-				<artifactId>spark-core_2.10</artifactId>
-				<version>[1.5.0, 1.6.2]</version>
+				<artifactId>spark-core_2.11</artifactId>
+				<version>2.0.0</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.spark</groupId>
-				<artifactId>spark-mllib_2.10</artifactId>
-				<version>[1.5.0, 1.6.2]</version>
+				<artifactId>spark-mllib_2.11</artifactId>
+				<version>2.0.0</version>
 				<scope>provided</scope>
 				<exclusions>
 					<exclusion>
@@ -76,8 +76,8 @@
 			</dependency>
 			<dependency>
 				<groupId>org.apache.spark</groupId>
-				<artifactId>spark-sql_2.10</artifactId>
-				<version>[1.5.0, 1.6.2]</version>
+				<artifactId>spark-sql_2.11</artifactId>
+				<version>2.0.0</version>
 				<scope>provided</scope>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
This PR is to add support Spark 2.0. I have tested with Spark 2.0.2 release like:

bin/spark-submit --master local --class org.jpmml.spark.EvaluationExample pmml-spark-example/target/example-1.0-SNAPSHOT.jar DecisionTreeIris.pmml Iris.csv /tmp/DecisionTreeIris

And it works.